### PR TITLE
Fix > Bug in SmartTagger and Add Unit Test

### DIFF
--- a/src/OpenVolumeMesh/Util/SmartTagger.hh
+++ b/src/OpenVolumeMesh/Util/SmartTagger.hh
@@ -20,7 +20,7 @@ public:
       assert(_tag_range <= std::numeric_limits<IntT>::max());
     }
     void reset() {
-      if (current_base_ > std::numeric_limits<IntT>::max() - tag_range_ * 2) {
+      if (current_base_ < std::numeric_limits<IntT>::max() - tag_range_ * 2) {
         current_base_ += tag_range_;
       } else {
         current_base_ = 0;
@@ -41,6 +41,10 @@ public:
 
     void set(Handle h, TagT tag) {
       prop_[h] = current_base_ + static_cast<IntT>(tag);
+    }
+
+    IntT current_base() const {
+        return current_base_;
     }
 
 

--- a/src/Unittests/unittests_smart_tagger.cc
+++ b/src/Unittests/unittests_smart_tagger.cc
@@ -57,5 +57,42 @@ TEST_F(TetrahedralMeshBase, SmartTaggerEnum) {
     }
 }
 
+TEST_F(TetrahedralMeshBase, SmartTaggerCurrentBase) {
+
+    generateTetrahedralMesh(mesh_);
+
+    auto tagger = SmartTagger<Entity::Vertex, uint8_t, bool>(mesh_, 2);
+    auto vh_true = VH(0);
+    auto vh_false = VH(1);
+
+    tagger.set(vh_true, true);
+    tagger.set(vh_false, false);
+    EXPECT_EQ(tagger.current_base(), 0);
+    EXPECT_EQ(tagger.get(vh_true), true);
+    EXPECT_EQ(tagger.get(vh_false), false);
+
+    for (uint8_t i = 0; i <= std::numeric_limits<uint8_t>::max() - 2*2; i += 2) {
+        tagger.reset();
+        EXPECT_EQ(tagger.current_base(), i + 2);
+
+        EXPECT_EQ(tagger.get(vh_true), false);
+        EXPECT_EQ(tagger.get(vh_false), false);
+        tagger.set(vh_true, true);
+        tagger.set(vh_false, false);
+        EXPECT_EQ(tagger.get(vh_true), true);
+        EXPECT_EQ(tagger.get(vh_false), false);
+    }
+
+    tagger.reset();
+    EXPECT_EQ(tagger.current_base(), 0);
+
+    EXPECT_EQ(tagger.get(vh_true), false);
+    EXPECT_EQ(tagger.get(vh_false), false);
+    tagger.set(vh_true, true);
+    tagger.set(vh_false, false);
+    EXPECT_EQ(tagger.get(vh_true), true);
+    EXPECT_EQ(tagger.get(vh_false), false);
+}
+
 
 // TODO: test SmartTagger overflow


### PR DESCRIPTION
Fix Bug (> to <) which led SmartTagger to always refill the entire vector after a reset.