### PR TITLE
Optimized Cell Vertex Iterators for Tet Mesh Kernel

### DIFF
--- a/src/OpenVolumeMesh/Core/TopologyKernel.cc
+++ b/src/OpenVolumeMesh/Core/TopologyKernel.cc
@@ -2188,7 +2188,14 @@ HalfEdgeHandle TopologyKernel::prev_halfedge_in_halfface(HalfEdgeHandle _heh, Ha
 
 std::vector<VertexHandle> TopologyKernel::get_halfface_vertices(HalfFaceHandle hfh) const
 {
-  return get_halfface_vertices(hfh, halfface(hfh).halfedges().front());
+    auto hehs = get_halfface_halfedges(hfh);
+    std::vector<VertexHandle> res;
+    const uint n = hehs.size();
+    res.reserve(n);
+    for (uint i = 0; i < n; ++i) res.emplace_back(from_vertex_handle(hehs[i]));
+    return res;
+
+    //return get_halfface_vertices(hfh, halfface(hfh).halfedges().front());
 }
 
 
@@ -2203,6 +2210,23 @@ std::vector<VertexHandle> TopologyKernel::get_halfface_vertices(HalfFaceHandle h
       return get_halfface_vertices(hfh, hf.halfedges()[i]);
 
   return std::vector<VertexHandle>();
+}
+
+std::vector<HalfEdgeHandle> TopologyKernel::get_halfface_halfedges(HalfFaceHandle hfh) const
+{
+    if ((hfh.idx() % 2) == 0)
+    {
+        return halfface(hfh).halfedges();
+    }
+    else
+    {
+        // Reverse the halfedges
+        const auto& hehs = halfface(hfh.opposite_handle()).halfedges();
+        const uint n = hehs.size();
+        std::vector<HalfEdgeHandle> res; res.reserve(n);
+        for (uint i = 0; i < n; ++i) res.emplace_back(hehs[n-1-i].opposite_handle());
+        return res;
+    }
 }
 
 

--- a/src/OpenVolumeMesh/Core/TopologyKernel.hh
+++ b/src/OpenVolumeMesh/Core/TopologyKernel.hh
@@ -743,6 +743,8 @@ public:
     std::vector<VertexHandle> get_halfface_vertices(HalfFaceHandle hfh, VertexHandle vh) const;
     /// Get vertices of a halfface orderd to start from from_vertex_handle(heh)
     std::vector<VertexHandle> get_halfface_vertices(HalfFaceHandle hfh, HalfEdgeHandle heh) const;
+    /// Get halfedges of halfface (unlike halfface(hfh).halfedges(), this does not create a copy of the face object)
+    std::vector<HalfEdgeHandle> get_halfface_halfedges(HalfFaceHandle hfh) const;
 
     /// check whether face _fh and edge _eh are incident
     bool is_incident( FaceHandle _fh, EdgeHandle _eh) const;

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.cc
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.cc
@@ -52,38 +52,15 @@ BaseIter(_mesh, _ref_h, _max_laps) {
     assert(_ref_h.is_valid());
 
     assert(_mesh->valence(_ref_h) == 4);
-    // TODO: refactor, this implementation is terribly inefficient:
 
-    TetrahedralMeshTopologyKernel::Cell cell = _mesh->cell(_ref_h);
+    const auto& cell_vhs = _mesh->get_cell_vertices(_ref_h);
 
-    // Get first half-face
-    HalfFaceHandle curHF = cell.halffaces()[0];
-    assert(curHF.is_valid());
+    // To be consistent with the previous implementation which used .to_vertex()
+    vertices_[0] = cell_vhs[1];
+    vertices_[1] = cell_vhs[2];
+    vertices_[2] = cell_vhs[0];
+    vertices_[3] = cell_vhs[3];
 
-    // Get first half-edge
-    assert(_mesh->valence(curHF.face_handle()) == 3);
-    HalfEdgeHandle curHE = *_mesh->halfface(curHF).halfedges().begin();
-    assert(curHE.is_valid());
-
-
-    vertices_[0] = _mesh->halfedge(curHE).to_vertex();
-
-    curHE = _mesh->next_halfedge_in_halfface(curHE, curHF);
-
-    vertices_[1] = _mesh->halfedge(curHE).to_vertex();
-
-    curHE = _mesh->next_halfedge_in_halfface(curHE, curHF);
-
-    vertices_[2] = _mesh->halfedge(curHE).to_vertex();
-
-
-    HalfFaceHandle other_hf = cell.halffaces()[1];
-    for (const auto vh: _mesh->halfface_vertices(other_hf)) {
-        if (vh == vertices_[0]) continue;
-        if (vh == vertices_[1]) continue;
-        if (vh == vertices_[2]) continue;
-        vertices_[3] = vh;
-    }
     cur_index_ = 0;
     BaseIter::cur_handle(vertices_[cur_index_]);
 }


### PR DESCRIPTION
Optimized for Tet Mesh specifically:
TetVertexIter
tet_vertices(CellHandle)
get_cell_vertices(...)
halfface_opposite_vertex(HalfFaceHandle)

The idea is to start with the three vertices of a halfface and then look for the 4th vertex in another halfface without copying edges/faces or searching all 4 halffaces.

Optimized for General Mesh:
get_halfface_vertices(HalfFaceHandle) (Avoid Face copy)