### PR TITLE
Updates to TetrahedralMeshTopologyKernel and TetrahedralMeshIterators:

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 master:
-    -
+
+    - TetrahedralMeshTopologyKernel:
+	- Behaviour change: TetVertexIterator now starts with `from` vertex of first halfedge of first cell halfface (previously: `to` vertex of same halffedge) for consistency with get_cell_vertices(). 
+	- Feature: vertex_opposite_halfface(CellHandle, VertexHandle) as inverse of halfface_opposite_vertex
+	- Improvement: Optimized get_cell_vertices()
 
 Version 3.3.2 (2025-04-25)
   - Bugfix (behavioural change!): TopologyKernel::genus() would return wrong results if garbage collection is required (it used entity counts that included deleted elements)

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.cc
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.cc
@@ -52,38 +52,13 @@ BaseIter(_mesh, _ref_h, _max_laps) {
     assert(_ref_h.is_valid());
 
     assert(_mesh->valence(_ref_h) == 4);
-    // TODO: refactor, this implementation is terribly inefficient:
 
-    TetrahedralMeshTopologyKernel::Cell cell = _mesh->cell(_ref_h);
+    const auto& cell_vhs = _mesh->get_cell_vertices(_ref_h);
+    vertices_[0] = cell_vhs[0];
+    vertices_[1] = cell_vhs[1];
+    vertices_[2] = cell_vhs[2];
+    vertices_[3] = cell_vhs[3];
 
-    // Get first half-face
-    HalfFaceHandle curHF = cell.halffaces()[0];
-    assert(curHF.is_valid());
-
-    // Get first half-edge
-    assert(_mesh->valence(curHF.face_handle()) == 3);
-    HalfEdgeHandle curHE = *_mesh->halfface(curHF).halfedges().begin();
-    assert(curHE.is_valid());
-
-
-    vertices_[0] = _mesh->halfedge(curHE).to_vertex();
-
-    curHE = _mesh->next_halfedge_in_halfface(curHE, curHF);
-
-    vertices_[1] = _mesh->halfedge(curHE).to_vertex();
-
-    curHE = _mesh->next_halfedge_in_halfface(curHE, curHF);
-
-    vertices_[2] = _mesh->halfedge(curHE).to_vertex();
-
-
-    HalfFaceHandle other_hf = cell.halffaces()[1];
-    for (const auto vh: _mesh->halfface_vertices(other_hf)) {
-        if (vh == vertices_[0]) continue;
-        if (vh == vertices_[1]) continue;
-        if (vh == vertices_[2]) continue;
-        vertices_[3] = vh;
-    }
     cur_index_ = 0;
     BaseIter::cur_handle(vertices_[cur_index_]);
 }

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.hh
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshIterators.hh
@@ -43,10 +43,11 @@ namespace OpenVolumeMesh {
 class TetrahedralMeshTopologyKernel;
 
 
-/** \brief Iterate over all vertices of a hexahedron in a specific order
+/** \brief Iterate over all vertices of a tetrahedron in a specific order
  *
- * Vertices are addressed in the following order: vertices of one halfface in ccw order, then the remaining vertex
- *
+ * Vertices are addressed in the following order: vertices of the tet's first halfface,
+ * starting with the halfface's first halfedge's from_vertex, then the remaining fourth vertex of the tet.
+ * Wrapper for get_cell_vertices(ch).
  */
 
 class OVM_EXPORT TetVertexIter : public BaseCirculator<CellHandle,

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.cc
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.cc
@@ -490,81 +490,74 @@ std::vector<VertexHandle> TetrahedralMeshTopologyKernel::get_cell_vertices(CellH
 
 std::vector<VertexHandle> TetrahedralMeshTopologyKernel::get_cell_vertices(CellHandle ch, VertexHandle vh) const
 {
-    HalfFaceHandle hfh = cell(ch).halffaces()[0];
-    Face f = halfface(hfh);
-    HalfEdgeHandle heh;
-    for (unsigned int i = 0; i < 3; ++i)
-    {
-        Edge e = halfedge(f.halfedges()[i]);
-        if (e.from_vertex() == vh)
-        {
-            heh = f.halfedges()[i];
-            break;
-        }
-    }
-    if (!heh.is_valid())
-    {
-        hfh = adjacent_halfface_in_cell(hfh, f.halfedges()[0]);
-        heh = prev_halfedge_in_halfface(opposite_halfedge_handle(f.halfedges()[0]), hfh);
-    }
-
-    return get_cell_vertices(hfh,heh);
-
+    auto vhs = get_halfface_vertices(vertex_opposite_halfface(ch, vh).opposite_handle());
+    vhs.insert(vhs.begin(), vh);
+    return vhs;
 }
 
 std::vector<VertexHandle> TetrahedralMeshTopologyKernel::get_cell_vertices(HalfFaceHandle hfh) const
 {
-    return get_cell_vertices(hfh, halfface(hfh).halfedges().front());
+    const CellHandle ch = incident_cell(hfh);
+    assert(ch.is_valid());
+    if (!ch.is_valid()) return {};
+
+    const auto& hfhs = cell(ch).halffaces();
+
+    // Start with the 3 vertices of the given halfface
+    std::vector<VertexHandle> cell_vhs = get_halfface_vertices(hfh);
+
+    // Look for the 4th vertex in another halfface of the cell
+    HalfFaceHandle other_hfh = (hfh!=hfhs[0])? hfhs[0] : hfhs[1];
+    const auto& other_hfh_vhs = get_halfface_vertices(other_hfh);
+    for (VertexHandle other_vh : other_hfh_vhs)
+    {
+        if (cell_vhs[0] != other_vh && cell_vhs[1] != other_vh && cell_vhs[2] != other_vh)
+        {
+            cell_vhs.push_back(other_vh);
+            return cell_vhs;
+        }
+    }
+
+    // If we end up here, the tet contains less than 4 vertices
+    assert(false);
+    return {};
 }
 
 std::vector<VertexHandle> TetrahedralMeshTopologyKernel::get_cell_vertices(HalfFaceHandle hfh, HalfEdgeHandle heh) const
 {
-    std::vector<VertexHandle> vertices;
+    auto vh0 = from_vertex_handle(heh);
+    auto vh1 = to_vertex_handle(heh);
 
-    // add vertices of halfface
-    for (unsigned int i = 0; i < 3; ++i)
-    {
-        Edge e = halfedge(heh);
-        vertices.push_back(e.from_vertex());
-        heh = next_halfedge_in_halfface(heh, hfh);
-    }
+    // Ensure that first 3 vertices are of hfh -> 4th vertex stays fixed
+    auto vhs = get_cell_vertices(hfh);
 
-    Cell c = cell(incident_cell(hfh));
-    HalfFaceHandle otherHfh = c.halffaces()[0];
-    if (otherHfh == hfh)
-        otherHfh = c.halffaces()[1];
+    // Ensure, we start with vh0 (note that vh0 cant be the 4th vertex cause heh must be contained in hfh)
+    if (vhs[1] == vh0) vhs = {vhs[1],vhs[2],vhs[0],vhs[3]};
+    else if (vhs[2] == vh0) vhs = {vhs[2],vhs[0],vhs[1],vhs[3]};
 
-    Face otherF = halfface(otherHfh);
+    // Ensure the 2nd vertex is vh1
+    if (vhs[2] == vh1) vhs = {vhs[0],vhs[1],vhs[2],vhs[3]};
+    else if (vhs[3] == vh1) vhs = {vhs[0],vhs[1],vhs[2],vhs[3]};
 
-    for (unsigned int i = 0; i < otherF.halfedges().size(); ++i)
-    {
-        HalfEdgeHandle he = otherF.halfedges()[i];
-        Edge e = halfedge(he);
-        if (std::find(vertices.begin(), vertices.end(), e.to_vertex()) == vertices.end())
-        {
-            vertices.push_back(e.to_vertex());
-            return vertices;
-        }
-    }
-
-    return vertices;
+    return vhs;
 }
 
 VertexHandle TetrahedralMeshTopologyKernel::halfface_opposite_vertex(HalfFaceHandle hfh) const
 {
-    if (is_boundary(hfh)) {
-        return InvalidVertexHandle;
-    }
+    return is_boundary(hfh)? InvalidVertexHandle : get_cell_vertices(hfh)[3];
+}
 
-    const std::vector<VertexHandle> base = get_halfface_vertices(hfh);
-    for (CellVertexIter it = cv_iter(incident_cell(hfh)); it.valid(); ++it) {
-        const VertexHandle vh = *it;
-        if (vh != base[0] && vh != base[1] && vh != base[2]) {
-            return vh;
+HalfFaceHandle TetrahedralMeshTopologyKernel::vertex_opposite_halfface(CellHandle ch, VertexHandle vh) const
+{
+    for (HalfFaceHandle hfh : cell(ch).halffaces())
+    {
+        const auto& vhs = get_halfface_vertices(hfh);
+        if (vhs[0] != vh && vhs[1] != vh && vhs[2] != vh)
+        {
+            return hfh;
         }
     }
-
-    return InvalidVertexHandle;
+    return InvalidHalfFaceHandle;
 }
 
 

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.hh
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.hh
@@ -73,12 +73,33 @@ public:
 
     HalfEdgeHandle add_halfedge(VertexHandle _fromVertex, VertexHandle _toVertex);
 
+    /// Get the 4 vertices of the tet ch in a specific order:
+    /// 1.-3. vertices of ch's first halfface, ccw, starting with the
+    /// first from_vertex of the halfface's first halfedge. 4. Then comes the 4th vertex of the tet.
     std::vector<VertexHandle> get_cell_vertices(CellHandle ch) const;
+
+    /// Get the 4 vertices of the tet ch in a specific order:
+    /// 1. vh, 2.-4. vertices of the halfface returned by vertex_opposite_halfface(ch, vh).opposite_handle()
+    /// (to preserve orientation).
     std::vector<VertexHandle> get_cell_vertices(CellHandle ch, VertexHandle vh) const;
+
+    /// Get the 4 vertices of hfh's incident cell in a specific order:
+    /// 1.-3. vertices of hfh, ccw, starting with the
+    /// first from_vertex of the halfface's first halfedge. 4. Then comes the 4th vertex of the tet.
+    /// Returns an empty vector, if the incident cell is invalid (hfh is boundary).
     std::vector<VertexHandle> get_cell_vertices(HalfFaceHandle hfh) const;
+
+    /// Get the 4 vertices of hfh's incident cell in a specific order:
+    /// 1. heh.to_vertex, 2. heh.to_vertex, 3. 3rd vertex of hfh, 4. 4th vertex of the tet.
+    /// heh is expected to be incident to hfh
     std::vector<VertexHandle> get_cell_vertices(HalfFaceHandle hfh, HalfEdgeHandle heh) const;
 
+    /// Get the vertex of the halfface's incident cell that is not contained in the halfface hfh.
+    /// If the incident cell is invalid (hfh is boundary), returns the invalid vertex handle
     VertexHandle halfface_opposite_vertex(HalfFaceHandle hfh) const;
+
+    /// Get the first halfface of the tet ch that does not contain the vertex vh.
+    HalfFaceHandle vertex_opposite_halfface(CellHandle ch, VertexHandle vh) const;
 
 
     VertexHandle collapse_edge(HalfEdgeHandle _heh);
@@ -95,6 +116,10 @@ public:
 
     typedef class TetVertexIter TetVertexIter;
 
+    /// Returns an iterator to iterate over the four vertices of a tetrahedron in a specific order:
+    /// 1.-3. vertices of the tet's first halfface,
+    /// starting with the halfface's first halfedge's from_vertex, then 4. the remaining fourth vertex of the tet.
+    /// Uses get_cell_vertices(ch).
     TetVertexIter tv_iter(CellHandle _ref_h, int _max_laps = 1) const {
         return TetVertexIter(_ref_h, this, _max_laps);
     }

--- a/src/Unittests/CMakeLists.txt
+++ b/src/Unittests/CMakeLists.txt
@@ -11,7 +11,9 @@ SET(SOURCE_FILES
     unittests_iterators.cc
     unittests_mesh_copies.cc
     unittests_smart_tagger.cc
-    unittests_properties.cc)
+    unittests_properties.cc
+    unittests_tet_mesh_navigation.cc
+)
 
 if (NOT TARGET OpenVolumeMesh::OpenVolumeMesh)
     find_package(OpenVolumeMesh REQUIRED)

--- a/src/Unittests/unittests_tet_mesh_navigation.cc
+++ b/src/Unittests/unittests_tet_mesh_navigation.cc
@@ -1,0 +1,268 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <OpenVolumeMesh/Mesh/TetrahedralMesh.hh>
+#include "unittests_common.hh"
+
+using namespace OpenVolumeMesh;
+
+/// Assert that the vertices 0, 1, 2, 3 are all present and correctly oriented
+void ASSERT_VERTICES_0123(TetrahedralMesh& mesh, CellHandle ch, const std::vector<VertexHandle>& vhs)
+{
+    ASSERT_EQ(vhs.size(), 4);
+    ASSERT_NE(std::find(vhs.begin(),vhs.end(),VH(0)), vhs.end());
+    ASSERT_NE(std::find(vhs.begin(),vhs.end(),VH(1)), vhs.end());
+    ASSERT_NE(std::find(vhs.begin(),vhs.end(),VH(2)), vhs.end());
+    ASSERT_NE(std::find(vhs.begin(),vhs.end(),VH(3)), vhs.end());
+
+    HalfFaceHandle hfh012 = mesh.find_halfface({vhs[0], vhs[1], vhs[2]});
+    HalfFaceHandle hfh023 = mesh.find_halfface({vhs[0], vhs[2], vhs[3]});
+    HalfFaceHandle hfh031 = mesh.find_halfface({vhs[0], vhs[3], vhs[1]});
+    HalfFaceHandle hfh132 = mesh.find_halfface({vhs[1], vhs[3], vhs[2]});
+
+    ASSERT_EQ(mesh.incident_cell(hfh012), ch);
+    ASSERT_EQ(mesh.incident_cell(hfh023), ch);
+    ASSERT_EQ(mesh.incident_cell(hfh031), ch);
+    ASSERT_EQ(mesh.incident_cell(hfh132), ch);
+}
+
+TEST_F(TetrahedralMeshBase, GetCellVerticesHfh)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    CellHandle ch = mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    auto vhs = mesh_.get_cell_vertices(hfh012);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh1);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh3);
+
+    vhs = mesh_.get_cell_vertices(hfh023);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh2);
+    ASSERT_EQ(vhs[2], vh3);
+    ASSERT_EQ(vhs[3], vh1);
+
+    vhs = mesh_.get_cell_vertices(hfh031);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh3);
+    ASSERT_EQ(vhs[2], vh1);
+    ASSERT_EQ(vhs[3], vh2);
+
+    vhs = mesh_.get_cell_vertices(hfh132);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh1);
+    ASSERT_EQ(vhs[1], vh3);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh0);
+}
+
+TEST_F(TetrahedralMeshBase, GetCellVerticesCh)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    CellHandle ch = mesh_.add_cell(vh0, vh1, vh2, vh3);
+
+    auto vhs = mesh_.get_cell_vertices(ch);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh1);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh3);
+}
+
+TEST_F(TetrahedralMeshBase, GetCellVerticesChVh)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    CellHandle ch = mesh_.add_cell(vh0, vh1, vh2, vh3);
+
+    auto vhs = mesh_.get_cell_vertices(ch, vh0);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+
+    vhs = mesh_.get_cell_vertices(ch, vh1);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh1);
+
+    vhs = mesh_.get_cell_vertices(ch, vh2);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh2);
+
+    vhs = mesh_.get_cell_vertices(ch, vh3);
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh3);
+}
+
+TEST_F(TetrahedralMeshBase, GetCellVerticesHfhHeh)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    CellHandle ch = mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    auto vhs = mesh_.get_cell_vertices(hfh012, mesh_.find_halfedge(vh0, vh1));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh1);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh3);
+
+    vhs = mesh_.get_cell_vertices(hfh012, mesh_.find_halfedge(vh1, vh2));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh1);
+    ASSERT_EQ(vhs[1], vh2);
+    ASSERT_EQ(vhs[2], vh0);
+    ASSERT_EQ(vhs[3], vh3);
+
+    vhs = mesh_.get_cell_vertices(hfh012, mesh_.find_halfedge(vh2, vh0));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh2);
+    ASSERT_EQ(vhs[1], vh0);
+    ASSERT_EQ(vhs[2], vh1);
+    ASSERT_EQ(vhs[3], vh3);
+
+    vhs = mesh_.get_cell_vertices(hfh023, mesh_.find_halfedge(vh0, vh2));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh2);
+    ASSERT_EQ(vhs[2], vh3);
+    ASSERT_EQ(vhs[3], vh1);
+
+    vhs = mesh_.get_cell_vertices(hfh023, mesh_.find_halfedge(vh2, vh3));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh2);
+    ASSERT_EQ(vhs[1], vh3);
+    ASSERT_EQ(vhs[2], vh0);
+    ASSERT_EQ(vhs[3], vh1);
+
+    vhs = mesh_.get_cell_vertices(hfh023, mesh_.find_halfedge(vh3, vh0));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh3);
+    ASSERT_EQ(vhs[1], vh0);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh1);
+
+    vhs = mesh_.get_cell_vertices(hfh031, mesh_.find_halfedge(vh0, vh3));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh0);
+    ASSERT_EQ(vhs[1], vh3);
+    ASSERT_EQ(vhs[2], vh1);
+    ASSERT_EQ(vhs[3], vh2);
+
+    vhs = mesh_.get_cell_vertices(hfh031, mesh_.find_halfedge(vh3, vh1));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh3);
+    ASSERT_EQ(vhs[1], vh1);
+    ASSERT_EQ(vhs[2], vh0);
+    ASSERT_EQ(vhs[3], vh2);
+
+    vhs = mesh_.get_cell_vertices(hfh031, mesh_.find_halfedge(vh1, vh0));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh1);
+    ASSERT_EQ(vhs[1], vh0);
+    ASSERT_EQ(vhs[2], vh3);
+    ASSERT_EQ(vhs[3], vh2);
+
+    vhs = mesh_.get_cell_vertices(hfh132, mesh_.find_halfedge(vh1, vh3));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh1);
+    ASSERT_EQ(vhs[1], vh3);
+    ASSERT_EQ(vhs[2], vh2);
+    ASSERT_EQ(vhs[3], vh0);
+
+    vhs = mesh_.get_cell_vertices(hfh132, mesh_.find_halfedge(vh3, vh2));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh3);
+    ASSERT_EQ(vhs[1], vh2);
+    ASSERT_EQ(vhs[2], vh1);
+    ASSERT_EQ(vhs[3], vh0);
+
+    vhs = mesh_.get_cell_vertices(hfh132, mesh_.find_halfedge(vh2, vh1));
+    ASSERT_VERTICES_0123(mesh_, ch, vhs);
+    ASSERT_EQ(vhs[0], vh2);
+    ASSERT_EQ(vhs[1], vh1);
+    ASSERT_EQ(vhs[2], vh3);
+    ASSERT_EQ(vhs[3], vh0);
+}
+
+TEST_F(TetrahedralMeshBase, HalffaceOppositeVertex)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(hfh012), vh3);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(hfh023), vh1);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(hfh031), vh2);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(hfh132), vh0);
+}
+
+TEST_F(TetrahedralMeshBase, VertexOppositeHalfface)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    CellHandle ch = mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    ASSERT_EQ(mesh_.vertex_opposite_halfface(ch, vh0), hfh132);
+    ASSERT_EQ(mesh_.vertex_opposite_halfface(ch, vh1), hfh023);
+    ASSERT_EQ(mesh_.vertex_opposite_halfface(ch, vh2), hfh031);
+    ASSERT_EQ(mesh_.vertex_opposite_halfface(ch, vh3), hfh012);
+}
+
+TEST_F(TetrahedralMeshBase, HalffaceOppositeVertexOppositeHalfface)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    CellHandle ch = mesh_.add_cell(vh0, vh1, vh2, vh3);
+
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(mesh_.vertex_opposite_halfface(ch, vh0)), vh0);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(mesh_.vertex_opposite_halfface(ch, vh1)), vh1);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(mesh_.vertex_opposite_halfface(ch, vh2)), vh2);
+    ASSERT_EQ(mesh_.halfface_opposite_vertex(mesh_.vertex_opposite_halfface(ch, vh3)), vh3);
+}


### PR DESCRIPTION
- Added vertex_opposite_halfface(CellHandle, VertexHandle) as inverse of halfface_opposite_vertex
- Optimized Variants of get_cell_vertices and added descriptions clarifying their specific vertex orderings
- TetVertexIter now returns the same vertex ordering as get_cell_vertices, meaning its first vertex is the first halfface's first halfedge's from_vertex instead of its to_vertex.
- Added Unittests to the above methods in unit tests_tet_mesh_navigation.cc