### PR TITLE
halfface halfedge and vertex iterator: avoid vector copying

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 master:
+  - HalffaceHalfEdgeIter and HalffaceVertexIter
+        - Improvements: Avoid heap allocation for better performance.
 
-    - TetrahedralMeshTopologyKernel:
+  - TetrahedralMeshTopologyKernel:
 	- Behaviour change: TetVertexIterator now starts with `from` vertex of first halfedge of first cell halfface (previously: `to` vertex of same halffedge) for consistency with get_cell_vertices(). 
 	- Feature: vertex_opposite_halfface(CellHandle, VertexHandle) as inverse of halfface_opposite_vertex
 	- Improvement: Optimized get_cell_vertices()

--- a/src/OpenVolumeMesh/Core/Iterators/HalfFaceVertexIter.cc
+++ b/src/OpenVolumeMesh/Core/Iterators/HalfFaceVertexIter.cc
@@ -10,35 +10,29 @@ BaseIter(_mesh, _ref_h, _max_laps) {
 
     if(!_ref_h.is_valid()) return;
 
-    const OpenVolumeMeshFace& halfface = _mesh->halfface(_ref_h);
-    const std::vector<HalfEdgeHandle>& hes = halfface.halfedges();
-    for(std::vector<HalfEdgeHandle>::const_iterator he_it = hes.begin();
-            he_it != hes.end(); ++he_it) {
-        vertices_.push_back(_mesh->halfedge(*he_it).from_vertex());
-    }
-
     cur_index_ = 0;
 
-    BaseIter::valid(vertices_.size() > 0);
+    BaseIter::valid(f_hehs().size() > 0);
     if(BaseIter::valid()) {
-        BaseIter::cur_handle(vertices_[cur_index_]);
+        BaseIter::cur_handle(cur_vh());
     }
 }
 
 
-HalfFaceVertexIter& HalfFaceVertexIter::operator--() {
-
+HalfFaceVertexIter& HalfFaceVertexIter::operator--()
+{
     if (cur_index_ == 0) {
-        cur_index_  = vertices_.size() - 1;
+        cur_index_  = f_hehs().size() - 1;
         --lap_;
-        if (lap_ < 0)
+        if (lap_ < 0) {
             BaseIter::valid(false);
+        }
     }
     else {
         --cur_index_;
     }
 
-    BaseIter::cur_handle(vertices_[cur_index_]);
+    BaseIter::cur_handle(cur_vh());
     return *this;
 }
 
@@ -46,15 +40,36 @@ HalfFaceVertexIter& HalfFaceVertexIter::operator--() {
 HalfFaceVertexIter& HalfFaceVertexIter::operator++() {
 
     ++cur_index_;
-    if (cur_index_ == vertices_.size())
+    if (cur_index_ == f_hehs().size())
     {
         cur_index_ = 0;
         ++lap_;
-        if (lap_ >= max_laps_)
+        if (lap_ >= max_laps_) {
             BaseIter::valid(false);
+        }
     }
-    BaseIter::cur_handle(vertices_[cur_index_]);
+    BaseIter::cur_handle(cur_vh());
     return *this;
+}
+
+const std::vector<HalfEdgeHandle>& HalfFaceVertexIter::f_hehs() const
+{
+    return mesh()->face(ref_handle_.face_handle()).halfedges();
+}
+
+VertexHandle HalfFaceVertexIter::cur_vh() const
+{
+    const auto& hehs = f_hehs();
+    if (ref_handle_.subidx()==1)
+    {
+        // Reversed Face
+        return mesh()->to_vertex_handle(hehs[hehs.size()-1-cur_index_]);
+    }
+    else
+    {
+        // Original Face
+        return mesh()->from_vertex_handle(hehs[cur_index_]);
+    }
 }
 
 } // namespace OpenVolumeMesh

--- a/src/OpenVolumeMesh/Core/Iterators/HalfFaceVertexIter.hh
+++ b/src/OpenVolumeMesh/Core/Iterators/HalfFaceVertexIter.hh
@@ -61,8 +61,11 @@ public:
     HalfFaceVertexIter& operator--();
 
 private:
-    std::vector<VertexHandle> vertices_;
     size_t cur_index_;
+
+    const std::vector<HalfEdgeHandle>& f_hehs() const;
+
+    VertexHandle cur_vh() const;
 };
 
 } // namespace OpenVolumeMesh

--- a/src/OpenVolumeMesh/Core/Iterators/detail/FaceHalfEdgeIterImpl.cc
+++ b/src/OpenVolumeMesh/Core/Iterators/detail/FaceHalfEdgeIterImpl.cc
@@ -19,8 +19,9 @@ FaceHalfEdgeIterImpl& FaceHalfEdgeIterImpl::operator++()
     if (cur_index_ >= halfedges_.size()) {
         cur_index_ = 0;
         ++lap_;
-        if (lap_ >= max_laps_)
+        if (lap_ >= max_laps_) {
             BaseIter::valid(false);
+        }
     }
     BaseIter::cur_handle(halfedges_[cur_index_]);
     return *this;

--- a/src/OpenVolumeMesh/Core/Iterators/detail/HalfFaceHalfEdgeIterImpl.cc
+++ b/src/OpenVolumeMesh/Core/Iterators/detail/HalfFaceHalfEdgeIterImpl.cc
@@ -5,41 +5,62 @@ namespace OpenVolumeMesh::detail {
 
 HalfFaceHalfEdgeIterImpl::HalfFaceHalfEdgeIterImpl(const HalfFaceHandle& _ref_h, const TopologyKernel* _mesh, int _max_laps) :
     BaseIter(_mesh, _ref_h, _max_laps),
-    halfedges_(_mesh->halfface(_ref_h).halfedges()),
     cur_index_(0)
 {
-    assert(halfedges_.size() > 0);
-    if (BaseIter::valid()) {
-        BaseIter::cur_handle(halfedges_[cur_index_]);
+    BaseIter::valid(f_hehs().size() > 0);
+    if(BaseIter::valid()) {
+        BaseIter::cur_handle(cur_heh());
     }
 }
 
-HalfFaceHalfEdgeIterImpl& HalfFaceHalfEdgeIterImpl::operator--() {
+HalfFaceHalfEdgeIterImpl& HalfFaceHalfEdgeIterImpl::operator--()
+{
     if (cur_index_ == 0) {
-        cur_index_ = halfedges_.size() - 1;
+        cur_index_ = f_hehs().size() - 1;
         --lap_;
-        if (lap_ < 0)
+        if (lap_ < 0) {
             BaseIter::valid(false);
+        }
     }
     else {
         --cur_index_;
     }
-    BaseIter::cur_handle(halfedges_[cur_index_]);
+    BaseIter::cur_handle(cur_heh());
     return *this;
 }
 
-HalfFaceHalfEdgeIterImpl& HalfFaceHalfEdgeIterImpl::operator++() {
+HalfFaceHalfEdgeIterImpl& HalfFaceHalfEdgeIterImpl::operator++()
+{
     ++cur_index_;
-    if (cur_index_ >= halfedges_.size()) {
+    if (cur_index_ >= f_hehs().size()) {
         cur_index_ = 0;
         ++lap_;
-        if (lap_ >= max_laps_)
+        if (lap_ >= max_laps_) {
             BaseIter::valid(false);
+        }
     }
-    BaseIter::cur_handle(halfedges_[cur_index_]);
+    BaseIter::cur_handle(cur_heh());
     return *this;
 }
 
+const std::vector<HalfEdgeHandle>& HalfFaceHalfEdgeIterImpl::f_hehs() const
+{
+    return mesh()->face(ref_handle_.face_handle()).halfedges();
+}
+
+HalfEdgeHandle HalfFaceHalfEdgeIterImpl::cur_heh() const
+{
+    if (ref_handle_.subidx()==1)
+    {
+        // Reversed Face
+        return f_hehs()[f_hehs().size()-1-cur_index_].opposite_handle();
+    }
+    else
+    {
+        // Original Face
+        return f_hehs()[cur_index_];
+    }
+}
 
 
 } // namespace OpenVolumeMesh::detail

--- a/src/OpenVolumeMesh/Core/Iterators/detail/HalfFaceHalfEdgeIterImpl.hh
+++ b/src/OpenVolumeMesh/Core/Iterators/detail/HalfFaceHalfEdgeIterImpl.hh
@@ -22,10 +22,11 @@ public:
     HalfFaceHalfEdgeIterImpl& operator--();
 
 private:
-    // TODO PERF: instead of making a copy, always iterate over the original
-    //            halfedges vector, just backwards + with opposite() for subidx 1
-    std::vector<HalfEdgeHandle> halfedges_;
     size_t cur_index_;
+
+    const std::vector<HalfEdgeHandle>& f_hehs() const;
+
+    HalfEdgeHandle cur_heh() const;
 };
 
 

--- a/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.cc
+++ b/src/OpenVolumeMesh/Mesh/TetrahedralMeshTopologyKernel.cc
@@ -504,12 +504,14 @@ std::vector<VertexHandle> TetrahedralMeshTopologyKernel::get_cell_vertices(HalfF
     const auto& hfhs = cell(ch).halffaces();
 
     // Start with the 3 vertices of the given halfface
-    std::vector<VertexHandle> cell_vhs = get_halfface_vertices(hfh);
+    std::vector<VertexHandle> cell_vhs;
+    cell_vhs.reserve(4);
+    for (VertexHandle vh : halfface_vertices(hfh))
+        cell_vhs.push_back(vh);
 
     // Look for the 4th vertex in another halfface of the cell
     HalfFaceHandle other_hfh = (hfh!=hfhs[0])? hfhs[0] : hfhs[1];
-    const auto& other_hfh_vhs = get_halfface_vertices(other_hfh);
-    for (VertexHandle other_vh : other_hfh_vhs)
+    for (VertexHandle other_vh : halfface_vertices(other_hfh))
     {
         if (cell_vhs[0] != other_vh && cell_vhs[1] != other_vh && cell_vhs[2] != other_vh)
         {

--- a/src/Unittests/unittests_iterators.cc
+++ b/src/Unittests/unittests_iterators.cc
@@ -131,6 +131,64 @@ TEST_F(TetrahedralMeshBase, VertexFaceIteratorTest) {
 
 }
 
+TEST_F(TetrahedralMeshBase, HalfFaceHalfEdgeIter)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    auto hfhe_it = mesh_.hfhe_iter(hfh012);
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh0, vh1));
+    ++hfhe_it;
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh1, vh2));
+    ++hfhe_it;
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh2, vh0));
+
+    hfhe_it = mesh_.hfhe_iter(hfh012.opposite_handle());
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh0, vh2));
+    ++hfhe_it;
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh2, vh1));
+    ++hfhe_it;
+    ASSERT_EQ(hfhe_it.cur_handle(), mesh_.find_halfedge(vh1, vh0));
+}
+
+TEST_F(TetrahedralMeshBase, HalfFaceVertexIter)
+{
+    VertexHandle vh0 = mesh_.add_vertex(Vec3d(0.0, 0.0, 0.0));
+    VertexHandle vh1 = mesh_.add_vertex(Vec3d(1.0, 0.0, 0.0));
+    VertexHandle vh2 = mesh_.add_vertex(Vec3d(1.0, 1.0, 0.0));
+    VertexHandle vh3 = mesh_.add_vertex(Vec3d(0.0, 1.0, 0.0));
+
+    HalfFaceHandle hfh012 = mesh_.add_halfface(vh0, vh1, vh2);
+    HalfFaceHandle hfh023 = mesh_.add_halfface(vh0, vh2, vh3);
+    HalfFaceHandle hfh031 = mesh_.add_halfface(vh0, vh3, vh1);
+    HalfFaceHandle hfh132 = mesh_.add_halfface(vh1, vh3, vh2);
+
+    mesh_.add_cell({hfh012, hfh023, hfh031, hfh132});
+
+    auto hfv_it = mesh_.hfv_iter(hfh012);
+    ASSERT_EQ(hfv_it.cur_handle(), vh0);
+    ++hfv_it;
+    ASSERT_EQ(hfv_it.cur_handle(), vh1);
+    ++hfv_it;
+    ASSERT_EQ(hfv_it.cur_handle(), vh2);
+
+    hfv_it = mesh_.hfv_iter(hfh012.opposite_handle());
+    ASSERT_EQ(hfv_it.cur_handle(), vh0);
+    ++hfv_it;
+    ASSERT_EQ(hfv_it.cur_handle(), vh2);
+    ++hfv_it;
+    ASSERT_EQ(hfv_it.cur_handle(), vh1);
+}
+
 TEST_F(HexahedralMeshBase, RangeForTest) {
     // no EXPECTs here, if it compiles, it'll work.
     generateHexahedralMesh(mesh_);


### PR DESCRIPTION
- In HFHE/HFV Iter: Use Vector reference and .opposite instead of copying face object.
- Add Unittests