### PR TITLE
Add default_prop support for enum and pointer

### DIFF
--- a/src/OpenVolumeMesh/Core/Properties/Defaults.hh
+++ b/src/OpenVolumeMesh/Core/Properties/Defaults.hh
@@ -55,7 +55,7 @@ struct default_prop
 // does not initialize the members. This is very narrow, but better to err
 // on the side of caution:
 template<typename T>
-struct default_prop<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
+struct default_prop<T, std::enable_if_t<std::is_scalar_v<T>>> {
     static inline constexpr const T value = {};
 };
 

--- a/src/Unittests/unittests_properties.cc
+++ b/src/Unittests/unittests_properties.cc
@@ -259,4 +259,9 @@ TEST_F(PolyhedralMeshBase, ProptypeDefaults)
     mesh_.create_private_property<std::array<std::tuple<double,int,float>, 10>, Entity::Vertex>();
 
     mesh_.create_private_property<std::vector<std::tuple<std::string,std::array<std::tuple<double,int,float>, 10>>>, Entity::Vertex>();
+
+    enum class Enum { A = 3, B = 7 };
+    mesh_.create_private_property<Enum, Entity::Vertex>();
+
+    mesh_.create_private_property<double*, Entity::Vertex>();
 }


### PR DESCRIPTION
Replaced the `is_arithmetic_v` with `is_scalar_v` to enable `default_prop` support for enums and raw pointers.

Safety Guarantee via Value-Initialization (`{}`):
 - **enum**: Initialized to `0`. 0 is guaranteed to be within the valid range of enum, even no enumerator evauluates to 0. ([C++ Draft dcl.enum#8](https://eel.is/c++draft/dcl.enum#8));
 - **pointer**: Initialized to `nullptr` ([Cpp reference](https://en.cppreference.com/cpp/language/pointer))